### PR TITLE
Allow manipulating values other than JSON

### DIFF
--- a/src/pointer.ts
+++ b/src/pointer.ts
@@ -33,12 +33,20 @@ export type ReferencedValue<T> = NestedValue<T>;
 type NestedValue<T, U = never> = T | (
     T extends object
         ? T extends U
-            ? never
+            ? NestedValue<Diff<T, U>, U>
             : T extends Array<infer I>
                 ? NestedValue<I, U | T>
-                : T[keyof T] | NestedValue<T[keyof T], U | T>
+                : NestedValue<T[keyof T], U | T>
         : never
     );
+
+type Diff<T extends object, M> = M extends infer U
+    ? T extends U
+        ? Exclude<keyof T, keyof U> extends never
+            ? never
+            : Pick<T, Exclude<keyof T, keyof U>>
+        : never
+    : never;
 
 /**
  * An error indicating a problem related to JSON pointer operations.

--- a/src/relativePointer.ts
+++ b/src/relativePointer.ts
@@ -8,7 +8,6 @@ import {
     JsonPointerLike,
     Entry,
     InvalidReferenceError,
-    RootStructure,
     ReferencedValue,
     RootValue,
 } from './pointer';
@@ -349,7 +348,7 @@ export class JsonRelativePointer implements JsonConvertible {
      *
      * @throws {InvalidReferenceError} If the pointer references the root of the structure.
      */
-    public unset<T extends RootStructure>(root: T, pointer = JsonPointer.root()): ReferencedValue<T> | undefined {
+    public unset<T extends RootValue>(root: T, pointer = JsonPointer.root()): ReferencedValue<T> | undefined {
         if (this.isKeyPointer()) {
             throw new JsonPointerError('Cannot write to a key.');
         }
@@ -358,7 +357,8 @@ export class JsonRelativePointer implements JsonConvertible {
         const remainderPointer = this.getRemainderPointer();
 
         if (!remainderPointer.isRoot()) {
-            return remainderPointer.unset(stack[stack.length - 1][1]);
+            // Given V = typeof value, and typeof value ⊆ ReferencedValue<T> → ReferencedValue<K> ⊆ ReferencedValue<T>
+            return remainderPointer.unset(stack[stack.length - 1][1]) as ReferencedValue<T>;
         }
 
         if (stack.length < 2) {
@@ -366,9 +366,10 @@ export class JsonRelativePointer implements JsonConvertible {
         }
 
         const segment = stack[stack.length - 1][0]!;
-        const structure = stack[stack.length - 2][1];
+        const parent = stack[stack.length - 2][1];
 
-        return JsonPointer.from([segment]).unset(structure);
+        // Given V = typeof value, and typeof value ⊆ ReferencedValue<T> → ReferencedValue<K> ⊆ ReferencedValue<T>
+        return JsonPointer.from([segment]).unset(parent) as ReferencedValue<T>;
     }
 
     /**

--- a/src/relativePointer.ts
+++ b/src/relativePointer.ts
@@ -271,7 +271,8 @@ export class JsonRelativePointer implements JsonConvertible {
             return segment;
         }
 
-        return this.getRemainderPointer().get(value as T);
+        // Given V = typeof value, and typeof value ⊆ ReferencedValue<T> → ReferencedValue<K> ⊆ ReferencedValue<T>
+        return this.getRemainderPointer().get(value) as ReferencedValue<T>;
     }
 
     /**

--- a/src/relativePointer.ts
+++ b/src/relativePointer.ts
@@ -1,4 +1,4 @@
-import {JsonConvertible, JsonStructure, JsonValue} from '@croct/json';
+import {JsonConvertible, JsonStructure} from '@croct/json';
 import {
     JsonPointer,
     JsonPointerSegments,
@@ -8,6 +8,9 @@ import {
     JsonPointerLike,
     Entry,
     InvalidReferenceError,
+    RootStructure,
+    ReferencedValue,
+    RootValue,
 } from './pointer';
 
 /**
@@ -245,10 +248,10 @@ export class JsonRelativePointer implements JsonConvertible {
     /**
      * Returns the value at the referenced location.
      *
-     * @param {JsonValue} root The value to read from.
+     * @param {RootValue} root The value to read from.
      * @param {JsonPointer} pointer The base pointer to resolve the current pointer against.
      *
-     * @returns {JsonValue} The value at the referenced location.
+     * @returns {ReferencedValue|JsonPointerSegment} The value at the referenced location.
      *
      * @throws {InvalidReferenceError} If a numeric segment references a non-array value.
      * @throws {InvalidReferenceError} If a string segment references an array value.
@@ -256,7 +259,7 @@ export class JsonRelativePointer implements JsonConvertible {
      * @throws {InvalidReferenceError} If there is no value at any level of the pointer.
      * @throws {InvalidReferenceError} If the pointer references the key of the root value.
      */
-    public get(root: JsonValue, pointer = JsonPointer.root()): JsonValue {
+    public get<T extends RootValue>(root: T, pointer = JsonPointer.root()): ReferencedValue<T>|JsonPointerSegment {
         const stack = this.getReferenceStack(root, pointer);
         const [segment, value] = stack[stack.length - 1];
 
@@ -268,7 +271,7 @@ export class JsonRelativePointer implements JsonConvertible {
             return segment;
         }
 
-        return this.getRemainderPointer().get(value);
+        return this.getRemainderPointer().get(value as T);
     }
 
     /**
@@ -276,12 +279,12 @@ export class JsonRelativePointer implements JsonConvertible {
      *
      * This method gracefully handles missing values by returning `false`.
      *
-     * @param {JsonValue} root The value to check if the reference exists in.
+     * @param {RootValue} root The value to check if the reference exists in.
      * @param {JsonPointer} pointer The base pointer to resolve the current pointer against.
      *
-     * @returns {JsonValue} Returns `true` if the value exists, `false` otherwise.
+     * @returns {boolean} Returns `true` if the value exists, `false` otherwise.
      */
-    public has(root: JsonValue, pointer: JsonPointer = JsonPointer.root()): boolean {
+    public has(root: RootValue, pointer: JsonPointer = JsonPointer.root()): boolean {
         try {
             this.get(root, pointer);
         } catch {
@@ -294,8 +297,8 @@ export class JsonRelativePointer implements JsonConvertible {
     /**
      * Sets the value at the referenced location.
      *
-     * @param {JsonValue} root The value to write to.
-     * @param {JsonValue} value The value to set at the referenced location.
+     * @param {RootValue} root The value to write to.
+     * @param {unknown} value The value to set at the referenced location.
      * @param {JsonPointer} pointer The base pointer to resolve the current pointer against.
      *
      * @throws {InvalidReferenceError} If the pointer references the root of the structure.
@@ -306,7 +309,7 @@ export class JsonRelativePointer implements JsonConvertible {
      * @throws {InvalidReferenceError} If setting the value to an array would cause it to become
      * sparse.
      */
-    public set(root: JsonValue, value: JsonValue, pointer = JsonPointer.root()): void {
+    public set(root: RootValue, value: unknown, pointer = JsonPointer.root()): void {
         if (this.isKeyPointer()) {
             throw new JsonPointerError('Cannot write to a key.');
         }
@@ -337,7 +340,7 @@ export class JsonRelativePointer implements JsonConvertible {
      * is a no-op. Pointers referencing array elements remove the element while keeping
      * the array dense.
      *
-     * @param {JsonValue} root The value to write to.
+     * @param {RootValue} root The value to write to.
      * @param {JsonPointer} pointer The base pointer to resolve the current pointer against.
      *
      * @returns {JsonValue} The unset value, or `undefined` if the referenced location
@@ -345,7 +348,7 @@ export class JsonRelativePointer implements JsonConvertible {
      *
      * @throws {InvalidReferenceError} If the pointer references the root of the structure.
      */
-    public unset(root: JsonValue, pointer = JsonPointer.root()): JsonValue | undefined {
+    public unset<T extends RootStructure>(root: T, pointer = JsonPointer.root()): ReferencedValue<T> | undefined {
         if (this.isKeyPointer()) {
             throw new JsonPointerError('Cannot write to a key.');
         }
@@ -354,7 +357,7 @@ export class JsonRelativePointer implements JsonConvertible {
         const remainderPointer = this.getRemainderPointer();
 
         if (!remainderPointer.isRoot()) {
-            return remainderPointer.unset(stack[stack.length - 1][1] as JsonStructure);
+            return remainderPointer.unset(stack[stack.length - 1][1]);
         }
 
         if (stack.length < 2) {
@@ -362,7 +365,7 @@ export class JsonRelativePointer implements JsonConvertible {
         }
 
         const segment = stack[stack.length - 1][0]!;
-        const structure = stack[stack.length - 2][1] as JsonStructure;
+        const structure = stack[stack.length - 2][1];
 
         return JsonPointer.from([segment]).unset(structure);
     }
@@ -370,20 +373,20 @@ export class JsonRelativePointer implements JsonConvertible {
     /**
      * Returns the stack of references to the value at the referenced location.
      *
-     * @param {JsonValue} root The value to read from.
+     * @param {RootValue} root The value to read from.
      * @param {JsonPointer} pointer The base pointer to resolve the current pointer against.
      *
-     * @returns {Entry[]} The list of entries in top-down order.
+     * @returns {Entry<ReferencedValue>[]} The list of entries in top-down order.
      *
      * @throws {InvalidReferenceError} If a numeric segment references a non-array value.
      * @throws {InvalidReferenceError} If a string segment references an array value.
      * @throws {InvalidReferenceError} If an array index is out of bounds.
      * @throws {InvalidReferenceError} If there is no value at any level of the pointer.
      */
-    private getReferenceStack(root: JsonValue, pointer: JsonPointer): Entry[] {
+    private getReferenceStack<T extends RootValue>(root: T, pointer: JsonPointer): Array<Entry<ReferencedValue<T>>> {
         const iterator = pointer.traverse(root);
         let current = iterator.next();
-        const stack: Entry[] = [];
+        const stack: Array<Entry<ReferencedValue<T>>> = [];
 
         while (current.done === false) {
             stack.push(current.value);
@@ -436,7 +439,7 @@ export class JsonRelativePointer implements JsonConvertible {
      *
      * @returns {boolean} `true` if the pointers are logically equal, `false` otherwise.
      */
-    public equals(other: any): other is this {
+    public equals(other: any): other is JsonRelativePointer {
         if (this === other) {
             return true;
         }

--- a/test/relativePointer.test.ts
+++ b/test/relativePointer.test.ts
@@ -6,6 +6,7 @@ import {
     JsonPointerError,
     JsonPointerLike,
     JsonPointerSegments,
+    RootValue,
 } from '../src';
 import {JsonRelativePointer, JsonRelativePointerLike} from '../src/relativePointer';
 
@@ -451,7 +452,7 @@ describe('A JSON Relative Pointer', () => {
     )(
         'should get value from %o starting from %s with pointer %s resulting in %s',
         (
-            root: JsonValue,
+            root: RootValue,
             basePointer: JsonPointer,
             relativePointer: JsonRelativePointer,
             result: JsonValue,
@@ -945,7 +946,7 @@ describe('A JSON Relative Pointer', () => {
     )(
         'should unset from %o at %s %s resulting in %o',
         (
-            root: JsonValue,
+            root: RootValue,
             basePointer: JsonPointer,
             relativePointer: JsonRelativePointer,
             result: JsonValue,
@@ -984,7 +985,7 @@ describe('A JSON Relative Pointer', () => {
     )(
         'should fail to unset from %o at %s %s because %S',
         (
-            root: JsonValue,
+            root: RootValue,
             basePointer: JsonPointer,
             relativePointer: JsonRelativePointer,
             error: string,


### PR DESCRIPTION
## Summary
The current implementation of the JSON pointer is limited to manipulating JSON values, even though the underlying logic can handle any data type. 

This PR refactors the typings to accept any value as input while ensuring the retrieval operations remain type-safe and aligned with the input structure. As a result, when types are defined correctly, the retrieved values will be constrained to the types present in the source input.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings